### PR TITLE
docs: add not about mayastor nvme_tcp init container check

### DIFF
--- a/website/content/v1.8/kubernetes-guides/configuration/storage.md
+++ b/website/content/v1.8/kubernetes-guides/configuration/storage.md
@@ -120,6 +120,8 @@ talosctl -n <node ip> service kubelet restart
 
 Continue setting up [Mayastor](https://mayastor.gitbook.io/introduction/quickstart/deploy-mayastor) using the official documentation.
 
+> Note: The Mayastor helm chart uses an init container that checks for the nvme_tcp module. It does not mount /sys and will not be able to find it. Easiest solution is to disable the init container.
+
 ### Piraeus / LINSTOR
 
 * [Piraeus-Operator](https://piraeus.io/)


### PR DESCRIPTION
The Mayastor helm chart ships with an init container that won't mount /sys and runs lsmod.
Add a note in the guide as this is not obvious.

I stumbled over this issue and found no good results on google. Had to search the Talos slack to get some hints.
Adding this so the information is publicly available.